### PR TITLE
Concurrent tests

### DIFF
--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,0 +1,2 @@
+junit.jupiter.execution.parallel.enabled = true
+junit.jupiter.execution.parallel.mode.default = concurrent 


### PR DESCRIPTION
Speeds up travis build 1-2 minutes, also very helpful locally.
The disadvantage is messed up output, possible fix would be to accumulate output and print only one time on test completion