### PR TITLE
Фикс интерфейсов. (java 9+)

### DIFF
--- a/src/main/java/by/radioegor146/source/ClassSourceBuilder.java
+++ b/src/main/java/by/radioegor146/source/ClassSourceBuilder.java
@@ -108,9 +108,9 @@ public class ClassSourceBuilder implements AutoCloseable {
             cppWriter.append("        JNINativeMethod __ngen_static_iface_methods[] = {\n");
             cppWriter.append(staticClassProvider.getMethods());
             cppWriter.append("        };\n\n");
-            cppWriter.append("        jclass clazz = utils::find_class_wo_static(env, ")
+            cppWriter.append("        jclass iface_methods_clazz = utils::find_class_wo_static(env, ")
                     .append(stringPool.get(staticClassProvider.getCurrentClassName().replace("/", "."))).append(");\n");
-            cppWriter.append("        if (clazz) env->RegisterNatives(clazz, __ngen_static_iface_methods, sizeof(__ngen_static_iface_methods) / sizeof(__ngen_static_iface_methods[0]));\n");
+            cppWriter.append("        if (iface_methods_clazz) env->RegisterNatives(iface_methods_clazz, __ngen_static_iface_methods, sizeof(__ngen_static_iface_methods) / sizeof(__ngen_static_iface_methods[0]));\n");
             cppWriter.append("        if (env->ExceptionCheck()) { fprintf(stderr, \"Exception occured while registering native_jvm for %s\\n\", ")
                     .append(stringPool.get(className.replace("/", ".")))
                     .append("); fflush(stderr); env->ExceptionDescribe(); env->ExceptionClear(); }\n");

--- a/src/main/java/by/radioegor146/special/ClInitSpecialMethodProcessor.java
+++ b/src/main/java/by/radioegor146/special/ClInitSpecialMethodProcessor.java
@@ -36,7 +36,6 @@ public class ClInitSpecialMethodProcessor implements SpecialMethodProcessor {
             instructions.add(new MethodInsnNode(Opcodes.INVOKESTATIC,
                     context.obfuscator.getStaticClassProvider().getCurrentClassName(),
                     context.nativeMethod.name, context.nativeMethod.desc, false));
-            instructions.add(new InsnNode(Opcodes.RETURN));
         } else {
             instructions.add(new MethodInsnNode(Opcodes.INVOKESTATIC, context.clazz.name,
                     "native_special_clinit" + context.methodIndex, context.method.desc, false));

--- a/src/main/java/by/radioegor146/special/ClInitSpecialMethodProcessor.java
+++ b/src/main/java/by/radioegor146/special/ClInitSpecialMethodProcessor.java
@@ -11,10 +11,12 @@ public class ClInitSpecialMethodProcessor implements SpecialMethodProcessor {
     @Override
     public String preProcess(MethodContext context) {
         String name = "native_special_clinit" + context.methodIndex;
-        context.proxyMethod = new MethodNode(Opcodes.ASM7,
-                Opcodes.ACC_NATIVE | Opcodes.ACC_PRIVATE | Opcodes.ACC_STATIC | Opcodes.ACC_SYNTHETIC,
-                name, context.method.desc, context.method.signature, new String[0]);
-        context.clazz.methods.add(context.proxyMethod);
+        if (!Util.getFlag(context.clazz.access, Opcodes.ACC_INTERFACE)) {
+            context.proxyMethod = new MethodNode(Opcodes.ASM7,
+                    Opcodes.ACC_NATIVE | Opcodes.ACC_PRIVATE | Opcodes.ACC_STATIC | Opcodes.ACC_SYNTHETIC,
+                    name, context.method.desc, context.method.signature, new String[0]);
+            context.clazz.methods.add(context.proxyMethod);
+        }
         return name;
     }
 
@@ -26,18 +28,20 @@ public class ClInitSpecialMethodProcessor implements SpecialMethodProcessor {
         instructions.add(new LdcInsnNode(Type.getObjectType(context.clazz.name)));
         instructions.add(new MethodInsnNode(Opcodes.INVOKESTATIC, context.obfuscator.getNativeDir() + "/Loader",
                 "registerNativesForClass", "(ILjava/lang/Class;)V", false));
-        instructions.add(new MethodInsnNode(Opcodes.INVOKESTATIC, context.clazz.name,
-                "native_special_clinit" + context.methodIndex, context.method.desc, false));
 
         if (Util.getFlag(context.clazz.access, Opcodes.ACC_INTERFACE)) {
             if (context.nativeMethod == null) {
                 throw new RuntimeException("Native method not created?!");
             }
-            context.proxyMethod.instructions.add(new MethodInsnNode(Opcodes.INVOKESTATIC,
+            instructions.add(new MethodInsnNode(Opcodes.INVOKESTATIC,
                     context.obfuscator.getStaticClassProvider().getCurrentClassName(),
                     context.nativeMethod.name, context.nativeMethod.desc, false));
-            context.proxyMethod.instructions.add(new InsnNode(Opcodes.RETURN));
+            instructions.add(new InsnNode(Opcodes.RETURN));
+        } else {
+            instructions.add(new MethodInsnNode(Opcodes.INVOKESTATIC, context.clazz.name,
+                    "native_special_clinit" + context.methodIndex, context.method.desc, false));
         }
+
         instructions.add(new InsnNode(Opcodes.RETURN));
     }
 }


### PR DESCRIPTION
Исправляет ошибку "error: declaration of '_jclass* clazz' shadows a parameter" при компиляции, а также "java.lang.IncompatibleClassChangeError: Method *.native_special_clinit0()V must be InterfaceMethodref constant" для java 9 и выше.