### PR TITLE
Improve build speed by reusing computations from previous builds

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.parallel=true
-org.gradle.daemon=false
+org.gradle.daemon=true
 org.gradle.configureondemand=true
 org.gradle.caching=true


### PR DESCRIPTION

[Gradle daemon](https://docs.gradle.org/current/userguide/gradle_daemon.html#header). The Daemon is a long-lived process that help to avoid the cost of JVM startup for every build. Since Gradle 3.0, Gradle daemon is enabled by default. For an older version, you should enable it by setting `org.gradle.daemon=true`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
